### PR TITLE
Update to PM4 & PHP8

### DIFF
--- a/src/xenialdan/libnbs/CustomInstrument.php
+++ b/src/xenialdan/libnbs/CustomInstrument.php
@@ -7,17 +7,17 @@ namespace xenialdan\libnbs;
 class CustomInstrument
 {
     /** @var int The instruments index */
-    public $index;
+    public int $index;
     /** @var string The name of the instrument. */
-    public $name;
+    public string $name;
     /** @var string The sound file of the instrument (just the filename, not the path). */
-    public $soundFileName;
+    public string $soundFileName;
     /** @var string Sound name */
-    public $sound = "";
+    public string $sound = "";
     /** @var int The pitch of the sound file. Just like the note blocks, this ranges from 0-87. Default is 45. */
-    public $pitch;
+    public int $pitch;
     /** @var bool Whether the piano should automatically press keys with this instrument when the marker passes them (0 or 1). */
-    public $pressKey;
+    public bool $pressKey;
 
     /**
      * Creates a CustomInstrument

--- a/src/xenialdan/libnbs/Layer.php
+++ b/src/xenialdan/libnbs/Layer.php
@@ -2,49 +2,46 @@
 
 namespace xenialdan\libnbs;
 
-use Ds\Map;
-
 /**
  * Represents a series of notes in Note Block Studio.
  * A Layer can have a maximum of one note per tick (20 ticks a second)
  */
 class Layer
 {
-    /** @var Map */
-    public $notesAtTicks;
+    /** @var array<int,Note> */
+    public array $notesAtTicks = [];
     /** @var string */
-    public $name = "";
+    public string $name = "";
     /** @var int */
-    public $volume = 100;
+    public int $volume = 100;
     /**
      * This is from OpenNoteBlockStudio
      * How much this layer is panned to the left/right. 0 is 2 blocks right, 100 is centre, 200 is 2 blocks left
      * @var int
      */
-    public $stereo = 100;
+    public int $stereo = 100;
 
     public function __construct(string $name, int $volume, int $stereo = 100)
     {
-        $this->notesAtTicks = new Map();
         $this->name = $name;
         $this->volume = $volume;
         $this->stereo = $stereo;
     }
 
     /**
-     * Gets the notes in the Layer with the tick they are created as a hash map
-     * @return Map of notes with the tick they are played at
+     * Gets the notes in the Layer with the tick they are created as an array
+     * @return Array of notes with the tick they are played at
      */
-    public function getNotesAtTicks(): Map
+    public function getNotesAtTicks(): array
     {
         return $this->notesAtTicks;
     }
 
     /**
-     * Sets the notes in the Layer with the tick they are created as a hash map
-     * @param Map $notesAtTicks
+     * Sets the notes in the Layer with the tick they are created as an array
+     * @param array $notesAtTicks
      */
-    public function setNotesAtTicks(Map $notesAtTicks): void
+    public function setNotesAtTicks(array $notesAtTicks): void
     {
         $this->notesAtTicks = $notesAtTicks;
     }
@@ -74,7 +71,7 @@ class Layer
      */
     public function getNote(int $tick): ?Note
     {
-        return $this->notesAtTicks->get($tick, null);
+        return $this->notesAtTicks[$tick] ?? null;
     }
 
     /**
@@ -84,7 +81,7 @@ class Layer
      */
     public function setNote(int $tick, Note $note): void
     {
-        $this->notesAtTicks->put($tick, $note);
+        $this->notesAtTicks[$tick] = $note;
     }
 
     /**

--- a/src/xenialdan/libnbs/Note.php
+++ b/src/xenialdan/libnbs/Note.php
@@ -8,9 +8,9 @@ namespace xenialdan\libnbs;
 class Note
 {
     /** @var int */
-    public $instrument;
+    public int $instrument;
     /** @var int */
-    public $key;
+     public int $key;
 
     /**
      * Note constructor.

--- a/src/xenialdan/libnbs/Note.php
+++ b/src/xenialdan/libnbs/Note.php
@@ -10,7 +10,7 @@ class Note
     /** @var int */
     public int $instrument;
     /** @var int */
-     public int $key;
+    public int $key;
 
     /**
      * Note constructor.

--- a/src/xenialdan/libnbs/Song.php
+++ b/src/xenialdan/libnbs/Song.php
@@ -64,7 +64,7 @@ class Song
      * Gets all Layers in this Song and their index
      * @return Array of Layers and their index
      */
-    public function getLayers(): array
+    public function getLayerHashMap(): array
     {
         return $this->layers;
     }

--- a/src/xenialdan/libnbs/Song.php
+++ b/src/xenialdan/libnbs/Song.php
@@ -4,40 +4,38 @@ declare(strict_types=1);
 
 namespace xenialdan\libnbs;
 
-use Ds\Map;
-
 /**
  * Represents a Note Block Studio project
  */
 class Song
 {
-    /** @var Map */
-    private $layerHashMap;
+    /** @var array<int,Layer> */
+    private array $layers;
     /** @var int */
-    private $songHeight;
+    private int $songHeight;
     /** @var int */
-    private $length;
+    private int $length;
     /** @var string */
-    private $title;
+    private string $title;
     /** @var string */
-    private $path;
+    private string $path;
     /** @var string */
-    private $author;
+    private string $author;
     /** @var string */
-    private $description;
+    private string $description;
     /** @var float */
-    private $speed;
+    private float $speed;
     /** @var float */
-    private $delay;
+    private float $delay;
     /** @var CustomInstrument[] */
-    private $customInstruments = [];
+    private array $customInstruments = [];
     /** @var int */
-    private $firstCustomInstrumentIndex;
+    private int $firstCustomInstrumentIndex;
 
     /**
      * Song constructor.
      * @param float $speed
-     * @param Map $layerHashMap
+     * @param array $layers
      * @param int $songHeight
      * @param int $length
      * @param string $title
@@ -47,11 +45,11 @@ class Song
      * @param int $firstCustomInstrumentIndex
      * @param CustomInstrument[] $customInstruments
      */
-    public function __construct(float $speed, Map $layerHashMap, int $songHeight, int $length, string $title, string $author, string $description, string $path, int $firstCustomInstrumentIndex, array $customInstruments)
+    public function __construct(float $speed, array $layers, int $songHeight, int $length, string $title, string $author, string $description, string $path, int $firstCustomInstrumentIndex, array $customInstruments)
     {
         $this->speed = $speed;
         $this->delay = 20 / $speed;
-        $this->layerHashMap = $layerHashMap;
+        $this->layers = $layers;
         $this->songHeight = $songHeight;
         $this->length = $length;
         $this->title = $title;
@@ -64,11 +62,11 @@ class Song
 
     /**
      * Gets all Layers in this Song and their index
-     * @return Map of Layers and their index
+     * @return Array of Layers and their index
      */
-    public function getLayerHashMap(): Map
+    public function getLayers(): array
     {
-        return $this->layerHashMap;
+        return $this->layers;
     }
 
     /**
@@ -164,7 +162,7 @@ class Song
 
     public function __toString()
     {
-        return "Song {$this->getTitle()} (" . basename($this->path) . "), author {$this->getAuthor()}, description {$this->getDescription()}, length {$this->getLength()}, speed {$this->getSpeed()}, delay {$this->getDelay()}, height {$this->getSongHeight()}, count {$this->getLayerHashMap()->count()}";
+        return "Song {$this->getTitle()} (" . basename($this->path) . "), author {$this->getAuthor()}, description {$this->getDescription()}, length {$this->getLength()}, speed {$this->getSpeed()}, delay {$this->getDelay()}, height {$this->getSongHeight()}, count ".count($this->getLayers());
     }
 
 }

--- a/src/xenialdan/libnbs/Song.php
+++ b/src/xenialdan/libnbs/Song.php
@@ -162,7 +162,7 @@ class Song
 
     public function __toString()
     {
-        return "Song {$this->getTitle()} (" . basename($this->path) . "), author {$this->getAuthor()}, description {$this->getDescription()}, length {$this->getLength()}, speed {$this->getSpeed()}, delay {$this->getDelay()}, height {$this->getSongHeight()}, count ".count($this->getLayers());
+        return "Song {$this->getTitle()} (" . basename($this->path) . "), author {$this->getAuthor()}, description {$this->getDescription()}, length {$this->getLength()}, speed {$this->getSpeed()}, delay {$this->getDelay()}, height {$this->getSongHeight()}, count ".count($this->getLayerHashMap());
     }
 
 }

--- a/virion.yml
+++ b/virion.yml
@@ -1,6 +1,6 @@
 name: libnbs
-version: 4.1.0
+version: 4.2.0
 antigen: xenialdan\libnbs
-api: [3.10.1]
-php: [7.2]
+api: [4.0.0]
+php: [8.0]
 author: XenialDan


### PR DESCRIPTION
## Introduction
This PR allows to use the latest version of PocketMine-MP (4.0.0) and the latest version of PHP compatible with pocketmine (8.0)

## Backwards compatibility
Maps have been replaced by arrays, so several of the functions have had their parameters and returns changed.
Affected functions:
- `Layer::getNotesAtTicks()`
- `Layer::setNotesAtTicks()`
- `NBSFile::setNote()`
- `Song::__construct()`
- `Song::getLayerHashMap()`

## Tests
This PR was tested using [PocketRadio](https://github.com/IvanCraft623/PocketRadio/tree/pm4)